### PR TITLE
A fix for #31 and #37

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV RENDERER_ACCESS_KEY=changeme CONCURRENCY=1 WINDOW_WIDTH=1024 WINDOW_HEIGHT=7
     ELECTRON_VERSION=1.6.1 ELECTRON_ENABLE_STACK_DUMPING=true ELECTRON_ENABLE_LOGGING=true
 
 WORKDIR /app
-EXPOSE 3000
-CMD ["xvfb-run", "--server-args=\"-screen 0 ${WINDOW_WIDTH}x${WINDOW_HEIGHT}x24\"", "./electron --disable-gpu src/server.js"]
 
 # Add subpixel hinting
 COPY .fonts.conf /root/.fonts.conf
@@ -33,3 +31,6 @@ RUN apt-get update && apt-get install -y nodejs && \
     apt-get remove -y nodejs && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
+
+EXPOSE 3000
+CMD ["sh", "-c", "xvfb-run --server-args=\"-screen 0 ${WINDOW_WIDTH}x${WINDOW_HEIGHT}x24\" ./electron --disable-gpu src/server.js"]


### PR DESCRIPTION
The docker `CMD` needs to start with a shell to support environment variables. (At least: in the preferred JSON-array syntax.)

[From the manual](https://docs.docker.com/engine/reference/builder/#cmd):

> Note: Unlike the shell form, the exec form does not invoke a command shell. This means that normal shell processing does not happen. For example, CMD [ "echo", "$HOME" ] will not do variable substitution on $HOME. If you want shell processing then either use the shell form or execute a shell directly, for example: CMD [ "sh", "-c", "echo $HOME" ]. When using the exec form and executing a shell directly, as in the case for the shell form, it is the shell that is doing the environment variable expansion, not docker.

