### PR TITLE
A fix for #31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN apt-get update && apt-get install -y nodejs && \
 COPY . /app
 
 EXPOSE 3000
-CMD ["sh", "-c", "xvfb-run --server-args=\"-screen 0 ${WINDOW_WIDTH}x${WINDOW_HEIGHT}x24\" ./electron --disable-gpu src/server.js"]
+CMD ["sh", "-c", "[ -e /tmp/.X99-lock ] && rm /tmp/.X99-lock; xvfb-run -e /dev/stdout --server-args=\"-screen 0 ${WINDOW_WIDTH}x${WINDOW_HEIGHT}x24\" ./electron --disable-gpu src/server.js"]


### PR DESCRIPTION
xvfb doesn't always quit nicely when the docker container is stopped. As a result, a lock-file may be present, blocking a next start of the container.

This is a crude fix to just always remove the lockfile before starting xvfb