### PR TITLE
Allow rendering of pages using RequireJS

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -152,6 +152,7 @@ exports.createWindow = function createWindow() {
       blinkFeatures: 'OverlayScrollbars', // Slimmer scrollbars
       allowDisplayingInsecureContent: true, // Show http content on https site
       allowRunningInsecureContent: true, // Run JS, CSS from http urls
+      nodeIntegration: false, // Disable exposing of Node.js symbols to DOM
     },
   });
 


### PR DESCRIPTION
See https://electron.atom.io/docs/faq/#i-can-not-use-jqueryrequirejsmeteorangularjs-in-electron for a more thorough explanation.